### PR TITLE
feat: Add `wallet_switchEthereumChain` and custom http client support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -469,8 +469,8 @@ class _MyHomePageState extends State<MyHomePage> {
       final Map<String, dynamic> resMap = jsonDecode(res.body);
       final abi = ContractAbi.fromJson(resMap['result'], '');
       final contract = DeployedContract(
-          abi, EthereumAddress.fromHex(ethereumTransaction.to));
-      final dataBytes = hexToBytes(ethereumTransaction.data);
+          abi, EthereumAddress.fromHex(ethereumTransaction.to!));
+      final dataBytes = hexToBytes(ethereumTransaction.data!);
       final funcBytes = dataBytes.take(4).toList();
       debugPrint("funcBytes $funcBytes");
       final maibiFunctions = contract.functions
@@ -792,7 +792,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Transaction _wcEthTxToWeb3Tx(WCEthereumTransaction ethereumTransaction) {
     return Transaction(
       from: EthereumAddress.fromHex(ethereumTransaction.from),
-      to: EthereumAddress.fromHex(ethereumTransaction.to),
+      to: EthereumAddress.fromHex(ethereumTransaction.to!),
       maxGas: ethereumTransaction.gasLimit != null
           ? int.tryParse(ethereumTransaction.gasLimit!)
           : null,
@@ -800,7 +800,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ? EtherAmount.inWei(BigInt.parse(ethereumTransaction.gasPrice!))
           : null,
       value: EtherAmount.inWei(BigInt.parse(ethereumTransaction.value ?? '0')),
-      data: hexToBytes(ethereumTransaction.data),
+      data: hexToBytes(ethereumTransaction.data!),
       nonce: ethereumTransaction.nonce != null
           ? int.tryParse(ethereumTransaction.nonce!)
           : null,

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/lib/models/ethereum/wc_ethereum_transaction.dart
+++ b/lib/models/ethereum/wc_ethereum_transaction.dart
@@ -5,22 +5,22 @@ part 'wc_ethereum_transaction.g.dart';
 @JsonSerializable()
 class WCEthereumTransaction {
   final String from;
-  final String to;
+  final String? to;
   final String? nonce;
   final String? gasPrice;
   final String? gas;
   final String? gasLimit;
   final String? value;
-  final String data;
+  final String? data;
   WCEthereumTransaction({
     required this.from,
-    required this.to,
+    this.to,
     this.nonce,
     this.gasPrice,
-    required this.gas,
+    this.gas,
     this.gasLimit,
     this.value,
-    required this.data,
+    this.data,
   });
 
   factory WCEthereumTransaction.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/ethereum/wc_ethereum_transaction.g.dart
+++ b/lib/models/ethereum/wc_ethereum_transaction.g.dart
@@ -10,13 +10,13 @@ WCEthereumTransaction _$WCEthereumTransactionFromJson(
     Map<String, dynamic> json) {
   return WCEthereumTransaction(
     from: json['from'] as String,
-    to: json['to'] as String,
+    to: json['to'] as String?,
     nonce: json['nonce'] as String?,
     gasPrice: json['gasPrice'] as String?,
     gas: json['gas'] as String?,
     gasLimit: json['gasLimit'] as String?,
     value: json['value'] as String?,
-    data: json['data'] as String,
+    data: json['data'] as String?,
   );
 }
 

--- a/lib/models/ethereum/wc_wallet_switch_ethereum_chain.dart
+++ b/lib/models/ethereum/wc_wallet_switch_ethereum_chain.dart
@@ -1,0 +1,5 @@
+class WCWalletSwitchEthereumChain {
+  String chainId;
+
+  WCWalletSwitchEthereumChain(this.chainId);
+}

--- a/lib/models/jsonrpc/json_rpc_request.g.dart
+++ b/lib/models/jsonrpc/json_rpc_request.g.dart
@@ -68,4 +68,5 @@ const _$WCMethodEnumMap = {
   WCMethod.ETH_SIGN_TYPE_DATA: 'eth_signTypedData',
   WCMethod.ETH_SIGN_TRANSACTION: 'eth_signTransaction',
   WCMethod.ETH_SEND_TRANSACTION: 'eth_sendTransaction',
+  WCMethod.WALLET_SWITCHETHEREUMCHAIN: 'wallet_switchEthereumChain',
 };

--- a/lib/models/wc_method.dart
+++ b/lib/models/wc_method.dart
@@ -21,4 +21,7 @@ enum WCMethod {
 
   @JsonValue("eth_sendTransaction")
   ETH_SEND_TRANSACTION,
+
+  @JsonValue("wallet_switchEthereumChain")
+  WALLET_SWITCHETHEREUMCHAIN,
 }

--- a/lib/utils/hex.dart
+++ b/lib/utils/hex.dart
@@ -1,0 +1,38 @@
+import 'dart:typed_data';
+
+import 'package:convert/convert.dart';
+
+String strip0x(String str) {
+  if (str.startsWith('0x')) {
+    return str.substring(2);
+  }
+  return str;
+}
+
+String bytesToHex(
+  List<int> bytes, {
+  bool include0x = false,
+  int? forcePadLength,
+  bool padToEvenLength = false,
+}) {
+  var encoded = hex.encode(bytes);
+
+  if (forcePadLength != null) {
+    assert(forcePadLength >= encoded.length);
+
+    final padding = forcePadLength - encoded.length;
+    encoded = ('0' * padding) + encoded;
+  }
+
+  if (padToEvenLength && encoded.length % 2 != 0) {
+    encoded = '0$encoded';
+  }
+
+  return (include0x ? '0x' : '') + encoded;
+}
+
+Uint8List hexToBytes(String hexStr) {
+  final bytes = hex.decode(strip0x(hexStr));
+  if (bytes is Uint8List) return bytes;
+  return Uint8List.fromList(bytes);
+}

--- a/lib/wallet_connect.dart
+++ b/lib/wallet_connect.dart
@@ -2,6 +2,7 @@ library wallet_connect;
 
 export 'package:wallet_connect/models/ethereum/wc_ethereum_sign_message.dart';
 export 'package:wallet_connect/models/ethereum/wc_ethereum_transaction.dart';
+export 'package:wallet_connect/models/ethereum/wc_wallet_switch_ethereum_chain.dart';
 export 'package:wallet_connect/models/wc_peer_meta.dart';
 export 'package:wallet_connect/models/session/wc_session.dart';
 export 'package:wallet_connect/wc_session_store.dart';

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -33,6 +33,8 @@ typedef CustomRequest = void Function(int id, String payload);
 typedef WalletSwitchEthereumChain = void Function(
     int id, WCWalletSwitchEthereumChain transaction);
 
+const DappDisconnectCode = -9898;
+
 class WCClient {
   late WebSocketChannel _webSocket;
   Stream _socketStream = Stream.empty();
@@ -319,6 +321,7 @@ class WCClient {
         final param = WCSessionUpdate.fromJson(request.params!.first);
         print('SESSION_UPDATE $param');
         if (!param.approved) {
+          onDisconnect?.call(DappDisconnectCode, null);
           killSession();
         }
         break;

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -90,8 +90,8 @@ class WCClient {
     required WCSession session,
     required WCPeerMeta peerMeta,
     HttpClient? customHttpClient,
-  }) {
-    _connect(
+  }) async {
+    await _connect(
       session: session,
       peerMeta: peerMeta,
     );
@@ -100,8 +100,8 @@ class WCClient {
   connectFromSessionStore(
     WCSessionStore sessionStore, {
     HttpClient? customHttpClient,
-  }) {
-    _connect(
+  }) async {
+    await _connect(
       fromSessionStore: true,
       session: sessionStore.session,
       peerMeta: sessionStore.peerMeta,

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -140,9 +140,10 @@ class WCClient {
     int? chainId,
     bool approved = true,
   }) async {
+    _chainId = chainId;
     final param = WCSessionUpdate(
       approved: approved,
-      chainId: chainId ?? _chainId,
+      chainId: _chainId,
       accounts: accounts,
     );
     final request = JsonRpcRequest(

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:uuid/uuid.dart';
 import 'package:wallet_connect/models/ethereum/wc_ethereum_sign_message.dart';
 import 'package:wallet_connect/models/ethereum/wc_ethereum_transaction.dart';
+import 'package:wallet_connect/models/ethereum/wc_wallet_switch_ethereum_chain.dart';
 import 'package:wallet_connect/models/exception/exceptions.dart';
 import 'package:wallet_connect/models/jsonrpc/json_rpc_error.dart';
 import 'package:wallet_connect/models/jsonrpc/json_rpc_error_response.dart';
@@ -29,6 +30,8 @@ typedef EthSign = void Function(int id, WCEthereumSignMessage message);
 typedef EthTransaction = void Function(
     int id, WCEthereumTransaction transaction);
 typedef CustomRequest = void Function(int id, String payload);
+typedef WalletSwitchEthereumChain = void Function(
+    int id, WCWalletSwitchEthereumChain transaction);
 
 class WCClient {
   late WebSocketChannel _webSocket;
@@ -52,6 +55,7 @@ class WCClient {
     this.onEthSign,
     this.onEthSignTransaction,
     this.onEthSendTransaction,
+    this.onWalletSwitchEthereumChain,
     this.onCustomRequest,
     this.onConnect,
   });
@@ -62,6 +66,7 @@ class WCClient {
   final EthSign? onEthSign;
   final EthTransaction? onEthSignTransaction, onEthSendTransaction;
   final CustomRequest? onCustomRequest;
+  final WalletSwitchEthereumChain? onWalletSwitchEthereumChain;
   final Function()? onConnect;
 
   WCSession? get session => _session;
@@ -100,8 +105,7 @@ class WCClient {
     );
   }
 
-  WCSessionStore get sessionStore =>
-      WCSessionStore(
+  WCSessionStore get sessionStore => WCSessionStore(
         session: _session!,
         peerMeta: _peerMeta!,
         peerId: _peerId!,
@@ -142,9 +146,7 @@ class WCClient {
       accounts: accounts,
     );
     final request = JsonRpcRequest(
-      id: DateTime
-          .now()
-          .millisecondsSinceEpoch,
+      id: DateTime.now().millisecondsSinceEpoch,
       method: WCMethod.SESSION_UPDATE,
       params: [param.toJson()],
     );
@@ -206,7 +208,7 @@ class WCClient {
     _remotePeerId = remotePeerId;
     _chainId = chainId;
     final bridgeUri =
-    Uri.parse(session.bridge.replaceAll('https://', 'wss://'));
+        Uri.parse(session.bridge.replaceAll('https://', 'wss://'));
     _webSocket = WebSocketChannel.connect(bridgeUri);
     _isConnected = true;
     if (fromSessionStore) {
@@ -254,7 +256,7 @@ class WCClient {
 
   _listen() {
     _socketStream.listen(
-          (event) async {
+      (event) async {
         print('DATA: $event ${event.runtimeType}');
         final Map<String, dynamic> decoded = json.decode("$event");
         print('DECODED: $decoded ${decoded.runtimeType}');
@@ -280,7 +282,7 @@ class WCClient {
 
   Future<String> _decrypt(WCSocketMessage socketMessage) async {
     final payload =
-    WCEncryptionPayload.fromJson(jsonDecode(socketMessage.payload));
+        WCEncryptionPayload.fromJson(jsonDecode(socketMessage.payload));
     final decrypted = await WCCipher.decrypt(payload, _session!.key);
     print("DECRYPTED: $decrypted");
     return decrypted;
@@ -373,6 +375,12 @@ class WCClient {
         print('ETH_SEND_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSendTransaction?.call(request.id, param);
+        break;
+      case WCMethod.WALLET_SWITCHETHEREUMCHAIN:
+        print('WALLET_SWITCHETHEREUMCHAIN $request');
+        final params = request.params!.first as Map<String, dynamic>;
+        onWalletSwitchEthereumChain?.call(request.id,
+            WCWalletSwitchEthereumChain(params['chainId'] as String));
         break;
       default:
     }

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -86,7 +86,7 @@ class WCClient {
 
   bool get isConnected => _isConnected;
 
-  connectNewSession({
+  Future<void> connectNewSession({
     required WCSession session,
     required WCPeerMeta peerMeta,
     HttpClient? customHttpClient,
@@ -97,7 +97,7 @@ class WCClient {
     );
   }
 
-  connectFromSessionStore(
+  Future<void> connectFromSessionStore(
     WCSessionStore sessionStore, {
     HttpClient? customHttpClient,
   }) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: wallet_connect
 description: Wallet Connect client made in love with dart.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/Orange-Wallet/wallet-connect-dart
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  hex: ^0.2.0
   web_socket_channel: ^2.1.0
   uuid: ^3.0.4
   http: ^0.13.3
   cryptography: ^2.0.2
   collection: ^1.15.0
   json_annotation: ^4.0.1
+  convert: ^3.0.1
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
for example, while we using https://app.uniswap.org, switch chain from the top right dropdown menu.

Wallet app should handle onWalletSwithEtherumChain, and update session or reject the request in the handler.
