### PR TITLE
fix: to address would be null when you deploy a smart contract

### DIFF
--- a/lib/models/ethereum/wc_ethereum_transaction.dart
+++ b/lib/models/ethereum/wc_ethereum_transaction.dart
@@ -5,7 +5,7 @@ part 'wc_ethereum_transaction.g.dart';
 @JsonSerializable()
 class WCEthereumTransaction {
   final String from;
-  final String to;
+  final String? to;
   final String? nonce;
   final String? gasPrice;
   final String? gas;

--- a/lib/models/ethereum/wc_ethereum_transaction.g.dart
+++ b/lib/models/ethereum/wc_ethereum_transaction.g.dart
@@ -10,7 +10,7 @@ WCEthereumTransaction _$WCEthereumTransactionFromJson(
     Map<String, dynamic> json) {
   return WCEthereumTransaction(
     from: json['from'] as String,
-    to: json['to'] as String,
+    to: json['to'] as String?,
     nonce: json['nonce'] as String?,
     gasPrice: json['gasPrice'] as String?,
     gas: json['gas'] as String?,


### PR DESCRIPTION
When us connect on the Ethereum remix using wallet connect and try to deploy using wallet connect package a exception is triggered because TO address is null.

Then, to address was changed to nullable