### PR TITLE
Connect two wallets with same dapp

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -283,7 +283,7 @@ class _MyHomePageState extends State<MyHomePage> {
     ));
   }
 
-  _onSessionRequest(int id, WCPeerMeta peerMeta) {
+  _onSessionRequest(int id, String peerId, WCPeerMeta peerMeta) {
     showDialog(
       context: context,
       builder: (_) => SessionRequestView(

--- a/lib/models/jsonrpc/json_rpc_request.dart
+++ b/lib/models/jsonrpc/json_rpc_request.dart
@@ -6,6 +6,7 @@ part 'json_rpc_request.g.dart';
 
 @JsonSerializable()
 class JsonRpcRequest {
+  @JsonKey(fromJson: _idFromValue)
   final int id;
   final String jsonrpc;
   @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
@@ -17,6 +18,8 @@ class JsonRpcRequest {
     this.method,
     required this.params,
   });
+
+  static int _idFromValue(value) => int.tryParse(value.toString()) ?? 0;
 
   factory JsonRpcRequest.fromJson(Map<String, dynamic> json) =>
       _$JsonRpcRequestFromJson(json);

--- a/lib/models/jsonrpc/json_rpc_request.g.dart
+++ b/lib/models/jsonrpc/json_rpc_request.g.dart
@@ -8,7 +8,7 @@ part of 'json_rpc_request.dart';
 
 JsonRpcRequest _$JsonRpcRequestFromJson(Map<String, dynamic> json) =>
     JsonRpcRequest(
-      id: json['id'] as int,
+      id: JsonRpcRequest._idFromValue(json['id']),
       jsonrpc: json['jsonrpc'] as String? ?? JSONRPC_VERSION,
       method: $enumDecodeNullable(_$WCMethodEnumMap, json['method'],
           unknownValue: JsonKey.nullForUndefinedEnumValue),

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -319,7 +319,7 @@ class WCClient {
     switch (request.method) {
       case WCMethod.SESSION_REQUEST:
         final param = WCSessionRequest.fromJson(request.params!.first);
-        //print('SESSION_REQUEST $param');
+        // print('SESSION_REQUEST $param');
         _handshakeId = request.id;
         _remotePeerId = param.peerId;
         _remotePeerMeta = param.peerMeta;
@@ -334,7 +334,7 @@ class WCClient {
         }
         break;
       case WCMethod.ETH_SIGN:
-        //print('ETH_SIGN $request');
+        // print('ETH_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -349,7 +349,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_PERSONAL_SIGN:
-        //print('ETH_PERSONAL_SIGN $request');
+        // print('ETH_PERSONAL_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -364,7 +364,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TYPE_DATA:
-        //print('ETH_SIGN_TYPE_DATA $request');
+        // print('ETH_SIGN_TYPE_DATA $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -379,17 +379,17 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TRANSACTION:
-        //print('ETH_SIGN_TRANSACTION $request');
+        // print('ETH_SIGN_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSignTransaction?.call(request.id, param);
         break;
       case WCMethod.ETH_SEND_TRANSACTION:
-        //print('ETH_SEND_TRANSACTION $request');
+        // print('ETH_SEND_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSendTransaction?.call(request.id, param);
         break;
       case WCMethod.WALLET_SWITCH_NETWORK:
-        //print('WALLET_SWITCH_NETWORK $request');
+        // print('WALLET_SWITCH_NETWORK $request');
         final params = WCWalletSwitchNetwork.fromJson(request.params!.first);
         onWalletSwitchNetwork?.call(request.id, int.parse(params.chainId));
         break;

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -24,7 +24,8 @@ import 'package:wallet_connect/wc_session_store.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-typedef SessionRequest = void Function(int id, WCPeerMeta peerMeta);
+typedef SessionRequest = void Function(
+    int id, String peerId, WCPeerMeta peerMeta);
 typedef SocketError = void Function(dynamic message);
 typedef SocketClose = void Function(int? code, String? reason);
 typedef EthSign = void Function(int id, WCEthereumSignMessage message);
@@ -323,7 +324,7 @@ class WCClient {
         _remotePeerId = param.peerId;
         _remotePeerMeta = param.peerMeta;
         _chainId = param.chainId;
-        onSessionRequest?.call(request.id, param.peerMeta);
+        onSessionRequest?.call(request.id, param.peerId, param.peerMeta);
         break;
       case WCMethod.SESSION_UPDATE:
         final param = WCSessionUpdate.fromJson(request.params!.first);

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -318,7 +318,7 @@ class WCClient {
     switch (request.method) {
       case WCMethod.SESSION_REQUEST:
         final param = WCSessionRequest.fromJson(request.params!.first);
-        // print('SESSION_REQUEST $param');
+        print('SESSION_REQUEST $param');
         _handshakeId = request.id;
         _remotePeerId = param.peerId;
         _remotePeerMeta = param.peerMeta;
@@ -333,7 +333,7 @@ class WCClient {
         }
         break;
       case WCMethod.ETH_SIGN:
-        // print('ETH_SIGN $request');
+        print('ETH_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -348,7 +348,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_PERSONAL_SIGN:
-        // print('ETH_PERSONAL_SIGN $request');
+        print('ETH_PERSONAL_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -363,7 +363,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TYPE_DATA:
-        // print('ETH_SIGN_TYPE_DATA $request');
+        print('ETH_SIGN_TYPE_DATA $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -378,17 +378,17 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TRANSACTION:
-        // print('ETH_SIGN_TRANSACTION $request');
+        print('ETH_SIGN_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSignTransaction?.call(request.id, param);
         break;
       case WCMethod.ETH_SEND_TRANSACTION:
-        // print('ETH_SEND_TRANSACTION $request');
+        print('ETH_SEND_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSendTransaction?.call(request.id, param);
         break;
       case WCMethod.WALLET_SWITCH_NETWORK:
-        // print('WALLET_SWITCH_NETWORK $request');
+        print('WALLET_SWITCH_NETWORK $request');
         final params = WCWalletSwitchNetwork.fromJson(request.params!.first);
         onWalletSwitchNetwork?.call(request.id, int.parse(params.chainId));
         break;

--- a/lib/wc_client.dart
+++ b/lib/wc_client.dart
@@ -319,7 +319,7 @@ class WCClient {
     switch (request.method) {
       case WCMethod.SESSION_REQUEST:
         final param = WCSessionRequest.fromJson(request.params!.first);
-        print('SESSION_REQUEST $param');
+        //print('SESSION_REQUEST $param');
         _handshakeId = request.id;
         _remotePeerId = param.peerId;
         _remotePeerMeta = param.peerMeta;
@@ -334,7 +334,7 @@ class WCClient {
         }
         break;
       case WCMethod.ETH_SIGN:
-        print('ETH_SIGN $request');
+        //print('ETH_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -349,7 +349,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_PERSONAL_SIGN:
-        print('ETH_PERSONAL_SIGN $request');
+        //print('ETH_PERSONAL_SIGN $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -364,7 +364,7 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TYPE_DATA:
-        print('ETH_SIGN_TYPE_DATA $request');
+        //print('ETH_SIGN_TYPE_DATA $request');
         final params = request.params!.cast<String>();
         if (params.length < 2) {
           throw InvalidJsonRpcParamsException(request.id);
@@ -379,17 +379,17 @@ class WCClient {
         );
         break;
       case WCMethod.ETH_SIGN_TRANSACTION:
-        print('ETH_SIGN_TRANSACTION $request');
+        //print('ETH_SIGN_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSignTransaction?.call(request.id, param);
         break;
       case WCMethod.ETH_SEND_TRANSACTION:
-        print('ETH_SEND_TRANSACTION $request');
+        //print('ETH_SEND_TRANSACTION $request');
         final param = WCEthereumTransaction.fromJson(request.params!.first);
         onEthSendTransaction?.call(request.id, param);
         break;
       case WCMethod.WALLET_SWITCH_NETWORK:
-        print('WALLET_SWITCH_NETWORK $request');
+        //print('WALLET_SWITCH_NETWORK $request');
         final params = WCWalletSwitchNetwork.fromJson(request.params!.first);
         onWalletSwitchNetwork?.call(request.id, int.parse(params.chainId));
         break;


### PR DESCRIPTION
#48 Solution

When two wallets are connected to the same dapp then we can only track using peerId.